### PR TITLE
docs: spec system updates and doc improvements

### DIFF
--- a/specs/SPEC_GUIDE.md
+++ b/specs/SPEC_GUIDE.md
@@ -39,6 +39,42 @@ Rules:
 
 ---
 
+## Status Values
+
+`status` in the front matter has three values:
+
+| `status`      | Meaning                                                                     |
+| ------------- | --------------------------------------------------------------------------- |
+| `planned`     | Feature is known and on the roadmap — spec may be at any level of fidelity. |
+| `in-progress` | Actively being worked on.                                                   |
+| `complete`    | Shipped and done.                                                           |
+
+Specs are **living documents** — they can receive changes from any team at any time, regardless of status. A design change, a new requirement, a tech assessment finding, or a dev discovery can all update a spec while it is `planned`, `in-progress`, or even after `complete` (for post-ship learnings). Always add a changelog entry when the spec changes.
+
+## Changelog
+
+The `## Changelog` table records every meaningful change to the spec. Columns:
+
+**`Author`** — who wrote this entry.
+
+**`Driver`** — the type of work or team that prompted the change:
+
+| `Driver`    | Meaning                                                                                 |
+| ----------- | --------------------------------------------------------------------------------------- |
+| `stubbed`   | Feature placeholder created — reserved but no detail yet.                               |
+| `spitball`  | Rough idea or early thinking captured.                                                  |
+| `blueprint` | Structured spec written or significantly updated — story, flow, and intent fleshed out. |
+| `design`    | UX or visual design decision.                                                           |
+| `ta`        | Tech assessment — architecture, feasibility, or sub-task breakdown.                     |
+| `dev`       | Finding or change that came out of active development.                                  |
+| `review`    | Change requested during code or spec review.                                            |
+
+**`Why`** — one sentence on why the change was made.
+
+**`Status`** — the feature's `status` at the time of this entry (`planned`, `in-progress`, or `complete`).
+
+---
+
 ## Templates
 
 ### Feature (`F-XXX`)
@@ -48,7 +84,7 @@ Rules:
 id: F-XXX
 type: feature
 epic: <epic-name>
-status: draft
+status: planned
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 ---
@@ -114,9 +150,9 @@ updated: YYYY-MM-DD
 
 ## Changelog
 
-| Date       | Description  | Initiated by | Why      |
-| ---------- | ------------ | ------------ | -------- |
-| YYYY-MM-DD | Spec created | <name>       | <reason> |
+| Date       | Description  | Author | Driver    | Why      | Status  |
+| ---------- | ------------ | ------ | --------- | -------- | ------- |
+| YYYY-MM-DD | Spec created | <name> | blueprint | <reason> | planned |
 ```
 
 ---
@@ -128,7 +164,7 @@ updated: YYYY-MM-DD
 id: B-XXX
 type: fix
 epic: <epic-name or null>
-status: draft
+status: planned
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 ---
@@ -189,9 +225,9 @@ updated: YYYY-MM-DD
 
 ## Changelog
 
-| Date       | Description  | Initiated by | Why      |
-| ---------- | ------------ | ------------ | -------- |
-| YYYY-MM-DD | Spec created | <name>       | <reason> |
+| Date       | Description  | Author | Driver    | Why      | Status  |
+| ---------- | ------------ | ------ | --------- | -------- | ------- |
+| YYYY-MM-DD | Spec created | <name> | blueprint | <reason> | planned |
 ```
 
 ---
@@ -203,7 +239,7 @@ updated: YYYY-MM-DD
 id: C-XXX
 type: chore
 epic: <epic-name or null>
-status: draft
+status: planned
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 ---
@@ -254,9 +290,9 @@ updated: YYYY-MM-DD
 
 ## Changelog
 
-| Date       | Description  | Initiated by | Why      |
-| ---------- | ------------ | ------------ | -------- |
-| YYYY-MM-DD | Spec created | <name>       | <reason> |
+| Date       | Description  | Author | Driver    | Why      | Status  |
+| ---------- | ------------ | ------ | --------- | -------- | ------- |
+| YYYY-MM-DD | Spec created | <name> | blueprint | <reason> | planned |
 ```
 
 ---

--- a/specs/chores/dx-improvements-db-tooling.md
+++ b/specs/chores/dx-improvements-db-tooling.md
@@ -92,6 +92,6 @@ Replaced with `lint-staged` (`pnpm lint-staged`):
 
 ## Changelog
 
-| Date       | Description  | Initiated by | Why                                            |
-| ---------- | ------------ | ------------ | ---------------------------------------------- |
-| 2026-03-25 | Spec created | kshaw        | Four DX papercuts found during Google SSO work |
+| Date       | Description  | Author | Driver                                         | Why | Stage |
+| ---------- | ------------ | ------ | ---------------------------------------------- | --- | ----- |
+| 2026-03-25 | Spec created | kshaw  | Four DX papercuts found during Google SSO work |

--- a/specs/chores/extract-profiles-db-service.md
+++ b/specs/chores/extract-profiles-db-service.md
@@ -2,7 +2,7 @@
 id: C-003
 type: chore
 epic: user-account
-status: draft
+status: planned
 created: 2026-03-26
 updated: 2026-03-26
 ---
@@ -67,6 +67,6 @@ Update `UserProfileDialog.tsx` to import and call these service functions instea
 
 ## Changelog
 
-| Date       | Description  | Initiated by | Why                                                             |
-| ---------- | ------------ | ------------ | --------------------------------------------------------------- |
-| 2026-03-26 | Spec created | copilot      | Feedback on PR #51 to move DB calls out of the dialog component |
+| Date       | Description  | Author  | Driver                                                          | Why | Stage |
+| ---------- | ------------ | ------- | --------------------------------------------------------------- | --- | ----- |
+| 2026-03-26 | Spec created | copilot | Feedback on PR #51 to move DB calls out of the dialog component |

--- a/specs/chores/standardize-tailwind-class-usage.md
+++ b/specs/chores/standardize-tailwind-class-usage.md
@@ -2,7 +2,7 @@
 id: C-001
 type: chore
 epic: null
-status: draft
+status: planned
 created: 2026-03-24
 updated: 2026-03-24
 ---
@@ -11,17 +11,18 @@ updated: 2026-03-24
 
 ## Flags
 
-| Flag | |
-|------|-|
-| DB Change | ⬜ |
-| Style Only | ✅ |
-| Env Update Required | ⬜ |
+| Flag                |     |
+| ------------------- | --- |
+| DB Change           | ⬜  |
+| Style Only          | ✅  |
+| Env Update Required | ⬜  |
 
 ## Problem
 
 Several components mix Tailwind utility classes with arbitrary CSS values, hardcoded hex colors, and raw pixel values instead of the project's design tokens (oklch CSS custom properties, spacing scale, font-size scale). This creates visual inconsistencies and makes future theme changes expensive — a single color update requires touching many files rather than one CSS variable.
 
 Examples observed:
+
 - `Hero.tsx` uses `style={{ color: '#3a5a3c' }}` inline instead of a Tailwind token.
 - Some components use `text-[14px]` arbitrary values instead of `text-sm`.
 - `Footer.tsx` mixes `gap-4` and `gap-[18px]` for logically equivalent spacing.
@@ -43,6 +44,7 @@ Audit all files in `src/components/` and `src/pages/` and apply the following ru
 - `src/pages/*.tsx`
 
 Out of scope:
+
 - `src/components/ui/` — shadcn primitives; do not modify unless explicitly upgrading a component.
 - Generated files (`database.types.ts`).
 - Mapbox canvas layer styles (JSON paint properties — not Tailwind).
@@ -50,12 +52,14 @@ Out of scope:
 ## Impact
 
 **Benefits:**
+
 - Consistent visual output across components.
 - Single-source-of-truth for colors via CSS custom properties.
 - Faster future theme changes (e.g., dark mode or brand refresh).
 - Reduces reviewer cognitive load — no ad-hoc color archaeology.
 
 **Tradeoffs:**
+
 - Purely mechanical refactor — no user-visible feature change.
 - Low risk but touches many files; should be done in a single focused PR to keep the diff reviewable.
 - Requires careful visual regression check (manual or screenshot diff).
@@ -77,20 +81,20 @@ Out of scope:
 ## Related Issues
 
 | Issue | Description | Status |
-|-------|-------------|--------|
+| ----- | ----------- | ------ |
 
 ## Related PRs
 
-| PR | Description | Status |
-|----|-------------|--------|
+| PR  | Description | Status |
+| --- | ----------- | ------ |
 
 ## Changelog
 
-| Date | Description | Initiated by | Why |
-|------|-------------|--------------|-----|
-| 2026-03-24 | Spec created | KS | New spec system |
+| Date       | Description  | Author | Driver          | Why | Stage |
+| ---------- | ------------ | ------ | --------------- | --- | ----- |
+| 2026-03-24 | Spec created | KS     | New spec system |
 
 ## Related PRs
 
-| PR | Description | Status |
-|----|-------------|--------|
+| PR  | Description | Status |
+| --- | ----------- | ------ |

--- a/specs/epics/trail-management/draw-trail/spec.md
+++ b/specs/epics/trail-management/draw-trail/spec.md
@@ -2,9 +2,9 @@
 id: F-001
 type: feature
 epic: trail-management
-status: draft
+status: in-progress
 created: 2026-03-24
-updated: 2026-03-24
+updated: 2026-03-26
 ---
 
 # Draw Trail
@@ -13,11 +13,11 @@ updated: 2026-03-24
 
 ## Flags
 
-| Flag | |
-|------|-|
-| DB Change | ✅ |
-| Style Only | ⬜ |
-| Env Update Required | ⬜ |
+| Flag                |     |
+| ------------------- | --- |
+| DB Change           | ✅  |
+| Style Only          | ⬜  |
+| Env Update Required | ⬜  |
 
 ## Problem
 
@@ -25,37 +25,55 @@ Admins and builders currently have no way to create new trail geometries directl
 
 ## Solution
 
-Add a draw mode to the map page using Mapbox Draw (`@mapbox/mapbox-gl-draw`) and / or `mapbox-gl-draw-snap-mode` . When a builder or admin activates draw mode, they can:
+Add a draw mode to the map page using Mapbox Draw (`@mapbox/mapbox-gl-draw`) and `mapbox-gl-draw-snap-mode`. When a builder or admin activates draw mode, they can:
 
 1. Click to place waypoints along a trail route on the live Mapbox basemap.
 2. Edit or delete waypoints before saving.
 3. Confirm the geometry and provide trail metadata (name, difficulty, surface, description) in a side panel form.
-4. Save — the trail LineString geometry and metadata are written to the `trails` table via the existing `bulk_trail_mutations` RPC or a new `insert_trail` RPC.
+4. Save — the trail `LineString` geometry and metadata are written to the `trails` table via the `upsert_trails` RPC.
 
 ### Starting New Trail
-Button to add new trail, opens draw mode + drawer
+
+An **Add Trail** button (builders/admins only) opens Mapbox Draw in draw mode and opens the `TrailDetailDrawer` pre-populated with defaults. The new trail uses a sentinel `id = -1` until persisted.
+
+### Editing Existing Trail
+
+Activating edit on an existing trail loads its geometry into the Mapbox Draw layer. The `TrailDetailDrawer` is already open and switches to edit mode.
 
 ### Deleting Trail
-Button in modal, with confirmation prompt.
+
+A **Delete** button in the drawer (edit mode, builders/admins only) with a confirmation prompt. Performs a **soft delete** by setting `deleted_at` on the trail — does not hard-delete the row.
 
 ### Cancelling Edit
-Button in modal, with confirmation prompt. Should undo all changes made during the edit session.
 
-### Editing
-- Click on Line, drag to adjust waypoints. Delete Button should remove waypoints.
-- Enter or Right click should end drawing.
-- Shift Click should Add new Vertices to End of Line
-- Shift-Alt Click should Add new Vertices to Start of Line
-- Space should toggle snap mode
-- Shift delete should remove the last vertex.
-- Delete should remove the selected vertex.
-- Ctrl-Z should undo the last action. 
-- Ctrl-Y should redo the last undone action.
+Cancel button in the drawer with a confirmation prompt. Reverts the Mapbox Draw layer to its pre-edit geometry state and resets the form.
+
+### Editing Interactions
+
+- Click on line → drag to adjust waypoints
+- Enter or Right-click → finish drawing
+- Shift+Click → add vertex to end of line
+- Shift+Alt+Click → add vertex to start of line
+- Space → toggle snap mode (snap-to-line / snap-to-point)
+- Shift+Delete → remove last vertex
+- Delete → remove selected vertex
+- Ctrl+Z → undo last action
+- Ctrl+Y → redo last undone action
 
 ![Draw Trail](./drawTrail.png)
 
 ### Permissions
+
 Draw mode is available to **builders and admins only**. Members and public visitors see a read-only map.
+
+## Sub-Tasks
+
+| Issue | Description                                                                      | Backend Stub |
+| ----- | -------------------------------------------------------------------------------- | :----------: |
+| #53   | Edit existing trail with Draw tool + snap                                        |      ✅      |
+| #54   | Create new trail (Add Trail button, `id = -1`, edit mode)                        |      ✅      |
+| #55   | Delete trail (soft delete, confirmation prompt)                                  |      ✅      |
+| #56   | Backend changes — geometry save on update, soft delete migration, insert via RPC |      —       |
 
 ## Out of Scope
 
@@ -68,15 +86,20 @@ Draw mode is available to **builders and admins only**. Members and public visit
 ## Testing
 
 **Unit tests:**
+
 - `trailEditSchema` Valibot schema validates required fields (name, difficulty), rejects missing geometry.
 
 **Integration tests:**
-- Authenticated admin or builder can POST a new trail via the RPC and it appears in `trails_view`.
+
+- Authenticated admin or builder can upsert a new trail via the RPC and it appears in `trails_view`.
 - Member or unauthenticated user receives an RLS denial when attempting the same insert.
 - Trail with duplicate name is rejected (unique constraint).
 - Backend warns on invalid geometry (e.g. fewer than 2 coordinates) — save is allowed but a warning is surfaced to the user.
+- Soft-deleted trail no longer appears in `trails_view`.
+- Member/anon cannot soft-delete a trail (RLS denial).
 
 **Edge cases:**
+
 - Network error mid-save — form shows error state and does not clear entered data.
 - Very long trail (500+ waypoints) — Mapbox Draw layer renders without lag.
 - User navigates away mid-draw — prompt to confirm discard.
@@ -90,24 +113,26 @@ Draw mode is available to **builders and admins only**. Members and public visit
 - Use `madrone-bark` button variant for the primary save action (project convention).
 - Geometry warnings (short trail, potential self-intersection) are surfaced in the UI but do not block save — backend stores as-is.
 - Draw accuracy depends on basemap zoom; no GPS snap in v1. Document this limitation in the UI.
-- Undo/redo within a draw session is out of scope for v1 — user can delete waypoints and redraw.
-- See issue #30 ("Task: Add Trail (Draw)") for prior discussion.
+- See issue #30 for prior discussion.
 
 ## Related Issues
 
-| Issue | Description | Status |
-|-------|-------------|--------|
+| Issue | Description                               | Status |
+| ----- | ----------------------------------------- | ------ |
+| #30   | [F-001] Draw Trail (parent)               | Open   |
+| #53   | Edit existing trail with Draw tool + snap | Open   |
+| #54   | Create new trail                          | Open   |
+| #55   | Delete trail (soft delete)                | Open   |
+| #56   | Backend changes                           | Open   |
 
 ## Related PRs
 
-| PR | Description | Status |
-|----|-------------|--------|
+| PR  | Description | Status |
+| --- | ----------- | ------ |
 
 ## Changelog
 
-| Date | Description | Initiated by | Why |
-|------|-------------|--------------|-----|
-| 2026-03-24 | Spec created | KS | New spec system |
-
-| PR | Description | Status |
-|----|-------------|--------|
+| Date       | Description                                                                                  | Author | Driver    | Why                                                          | Status      |
+| ---------- | -------------------------------------------------------------------------------------------- | ------ | --------- | ------------------------------------------------------------ | ----------- |
+| 2026-03-24 | Spec created                                                                                 | KS     | blueprint | New spec system                                              | planned     |
+| 2026-03-26 | Sub-tasks defined; edit/create/delete/backend issues created (#53–56); spec updated to match | KS     | ta        | Tech assessment surfaced backend gaps and sub-task breakdown | in-progress |

--- a/specs/epics/trail-management/spec.md
+++ b/specs/epics/trail-management/spec.md
@@ -2,7 +2,7 @@
 id: E-001
 type: epic
 epic: null
-status: active
+status: in-progress
 created: 2026-03-24
 updated: 2026-03-24
 ---
@@ -11,7 +11,7 @@ updated: 2026-03-24
 
 ## Problem
 
-Primarily for Trail Stewards! We often use multiple apps like Gaia and Trailforks to locate areas for maintanance or for new trails. In addition we have to manage other spatial data ourselves, like elevation, land owner, and land cover. A trail management system integrated into the app would centralize all trail data, eliminate the need for external GIS tools, and allow stewards to maintain their trails end-to-end from the browser. This is a helpuful feature for steward adoption and long-term data integrity. Additionally Sharing read access between users / user groups outside of a payed app like trailforks would be valuable. 
+Primarily for Trail Stewards! We often use multiple apps like Gaia and Trailforks to locate areas for maintanance or for new trails. In addition we have to manage other spatial data ourselves, like elevation, land owner, and land cover. A trail management system integrated into the app would centralize all trail data, eliminate the need for external GIS tools, and allow stewards to maintain their trails end-to-end from the browser. This is a helpuful feature for steward adoption and long-term data integrity. Additionally Sharing read access between users / user groups outside of a payed app like trailforks would be valuable.
 
 ## Solution
 
@@ -32,19 +32,19 @@ Builders can share draft trail networks with other builders before any trail bre
 
 ## User Roles
 
-| Role    | Read | Write | Share drafts |
-|---------|------|-------|--------------|
-| Public  | ✓    |       |              |
-| Member  | ✓    |       |              |
+| Role    | Read | Write | Share drafts            |
+| ------- | ---- | ----- | ----------------------- |
+| Public  | ✓    |       |                         |
+| Member  | ✓    |       |                         |
 | Builder | ✓    | ✓     | ✓ (with other builders) |
-| Admin   | ✓    | ✓     | ✓            |
+| Admin   | ✓    | ✓     | ✓                       |
 
 ## Features
 
-| ID    | Type    | Name                                              | Status | Spec |
-|-------|---------|---------------------------------------------------|--------|------|
-| F-001 | feature | Draw Trail                                        | draft  | [spec](./draw-trail/spec.md) |
-| F-002 | feature | Trail Elevation Profile                           | draft  | [spec](./trail-elevation-profile/spec.md) |
+| ID    | Type    | Name                    | Status | Spec                                      |
+| ----- | ------- | ----------------------- | ------ | ----------------------------------------- |
+| F-001 | feature | Draw Trail              | draft  | [spec](./draw-trail/spec.md)              |
+| F-002 | feature | Trail Elevation Profile | draft  | [spec](./trail-elevation-profile/spec.md) |
 
 ## Work Plans (Future)
 
@@ -57,4 +57,3 @@ Items explicitly deferred to later epics — not out of scope forever:
 - **User-generated content** — allow users to submit photos, reviews, and trail conditions.
 - **Additional Layers** — support for overlaying additional data layers on the map, such as soil types, vegetation, and land use.
 - **Offline support** — cached map tiles and trail data for field use without connectivity.
-

--- a/specs/epics/trail-management/trail-elevation-profile/spec.md
+++ b/specs/epics/trail-management/trail-elevation-profile/spec.md
@@ -2,7 +2,7 @@
 id: F-002
 type: feature
 epic: trail-management
-status: draft
+status: planned
 created: 2026-03-24
 updated: 2026-03-24
 ---
@@ -13,11 +13,11 @@ updated: 2026-03-24
 
 ## Flags
 
-| Flag | |
-|------|-|
-| DB Change | ✅ |
-| Style Only | ⬜ |
-| Env Update Required | ⬜ |
+| Flag                |     |
+| ------------------- | --- |
+| DB Change           | ✅  |
+| Style Only          | ⬜  |
+| Env Update Required | ⬜  |
 
 ## Problem
 
@@ -32,6 +32,7 @@ When a user selects a trail, display an elevation profile chart in the `TrailDet
 **Elevation data strategy — one-time fetch, persisted as 3D geometry:**
 
 ### Initial Solution
+
 Elevation is fetched once from the Mapbox Terrain raster source and written back to the database as a `LineStringZ` geometry. It is never re-fetched at view time — the chart reads z-coordinates directly from the stored geometry. 10m resolution to start.
 
 **Fetch process:**
@@ -57,17 +58,20 @@ Elevation is fetched once from the Mapbox Terrain raster source and written back
 ## Testing
 
 **Unit tests:**
+
 - `resampleLineString(coords, spacingMetres)` — returns evenly-spaced points at correct intervals for a known geometry.
 - `parseElevationProfile(linestringZ)` — returns `{ distance: number[], elevation: number[] }` from a 3D coordinate array.
 - Distance accumulation is correct for a known 3-point geometry.
 - Handles empty coordinate array gracefully (returns empty arrays, no throw).
 
 **Integration tests:**
+
 - After saving a new trail, the stored geometry includes z-coordinates.
 - Admin or builder can trigger bulk elevation sync — all trails in `trails_view` have z-coordinates after sync completes.
 - Member or unauthenticated user cannot call `update_trail_geometry` RPC (RLS denial).
 
 **Edge cases:**
+
 - Trail with only 2 waypoints — resampling produces intermediate points; profile renders correctly.
 - Flat trail (all z identical) — renders a flat line, no division-by-zero.
 - Missing Mapbox token — sync tool is disabled; chart shows "elevation data unavailable" if z-coords are absent.
@@ -87,20 +91,20 @@ Elevation is fetched once from the Mapbox Terrain raster source and written back
 ## Related Issues
 
 | Issue | Description | Status |
-|-------|-------------|--------|
+| ----- | ----------- | ------ |
 
 ## Related PRs
 
-| PR | Description | Status |
-|----|-------------|--------|
+| PR  | Description | Status |
+| --- | ----------- | ------ |
 
 ## Changelog
 
-| Date | Description | Initiated by | Why |
-|------|-------------|--------------|-----|
-| 2026-03-24 | Spec created | KS | New spec system |
+| Date       | Description  | Author | Driver          | Why | Stage |
+| ---------- | ------------ | ------ | --------------- | --- | ----- |
+| 2026-03-24 | Spec created | KS     | New spec system |
 
 ## Related PRs
 
-| PR | Description | Status |
-|----|-------------|--------|
+| PR  | Description | Status |
+| --- | ----------- | ------ |

--- a/specs/epics/user-account/google-sso-auth/spec.md
+++ b/specs/epics/user-account/google-sso-auth/spec.md
@@ -123,10 +123,10 @@ No RLS policy grants `pending` any access, so unapproved users are locked out at
 
 ## Changelog
 
-| Date       | Description                                                                              | Initiated by | Why                                                                              |
-| ---------- | ---------------------------------------------------------------------------------------- | ------------ | -------------------------------------------------------------------------------- |
-| 2026-03-25 | Spec created                                                                             | kshaw        | Google SSO needed for production; email/password unsuitable for volunteer org    |
-| 2026-03-25 | Added approval gate: `pending` role for new OAuth sign-ups                               | kshaw        | Open self-registration unsafe; admins must vet new users before granting access  |
-| 2026-03-25 | Replaced `approved` boolean with `pending` role                                          | kshaw        | Role-as-state gives RLS enforcement for free; no per-policy `AND` clauses needed |
-| 2026-03-25 | Removed `isProduction` email/password gating; SSO only in all envs                       | kshaw        | Simplifies auth surface; dev seed users cover testing needs without a UI         |
-| 2026-03-25 | Closes [#27](https://github.com/ladysmith-trail-stewards/lts/issues/27) — Swapped to SSO | kshaw        | Email/password auth removed in favour of Google SSO                              |
+| Date       | Description                                                                              | Author | Driver                                                                           | Why | Stage |
+| ---------- | ---------------------------------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------- | --- | ----- |
+| 2026-03-25 | Spec created                                                                             | kshaw  | Google SSO needed for production; email/password unsuitable for volunteer org    |
+| 2026-03-25 | Added approval gate: `pending` role for new OAuth sign-ups                               | kshaw  | Open self-registration unsafe; admins must vet new users before granting access  |
+| 2026-03-25 | Replaced `approved` boolean with `pending` role                                          | kshaw  | Role-as-state gives RLS enforcement for free; no per-policy `AND` clauses needed |
+| 2026-03-25 | Removed `isProduction` email/password gating; SSO only in all envs                       | kshaw  | Simplifies auth surface; dev seed users cover testing needs without a UI         |
+| 2026-03-25 | Closes [#27](https://github.com/ladysmith-trail-stewards/lts/issues/27) — Swapped to SSO | kshaw  | Email/password auth removed in favour of Google SSO                              |

--- a/specs/epics/user-account/spec.md
+++ b/specs/epics/user-account/spec.md
@@ -1,7 +1,7 @@
 ---
 id: E-002
 type: epic
-status: active
+status: in-progress
 created: 2026-03-25
 updated: 2026-03-25
 ---
@@ -12,7 +12,7 @@ Features that allow authenticated users to manage their own account — profile 
 
 ## Features
 
-| ID | Feature | Status |
-|----|---------|--------|
+| ID    | Feature                                                | Status     |
+| ----- | ------------------------------------------------------ | ---------- |
 | F-004 | [Google SSO Authentication](./google-sso-auth/spec.md) | `complete` |
-| F-003 | [User Profile Dialog](./user-profile-dialog/spec.md) | `draft` |
+| F-003 | [User Profile Dialog](./user-profile-dialog/spec.md)   | `draft`    |

--- a/specs/epics/user-account/user-profile-dialog/spec.md
+++ b/specs/epics/user-account/user-profile-dialog/spec.md
@@ -2,7 +2,7 @@
 id: F-003
 type: feature
 epic: user-account
-status: draft
+status: planned
 created: 2026-03-25
 updated: 2026-03-25
 ---

--- a/src/components/UserProfileDialog.tsx
+++ b/src/components/UserProfileDialog.tsx
@@ -34,23 +34,25 @@ export function UserProfileDialog({ open, onOpenChange }: Props) {
   useEffect(() => {
     if (!open || !user) return;
 
-    setLoadingProfile(true);
-    supabase
-      .from('profiles')
-      .select('name, bio')
-      .eq('auth_user_id', user.id)
-      .single()
-      .then(({ data, error }) => {
-        setLoadingProfile(false);
-        if (error) {
-          toast.error('Failed to load profile. Please try again.');
-          return;
-        }
-        if (data) {
-          setName(data.name ?? '');
-          setBio(data.bio ?? '');
-        }
-      });
+    async function fetchProfile() {
+      setLoadingProfile(true);
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('name, bio')
+        .eq('auth_user_id', user!.id)
+        .single();
+      setLoadingProfile(false);
+      if (error) {
+        toast.error('Failed to load profile. Please try again.');
+        return;
+      }
+      if (data) {
+        setName(data.name ?? '');
+        setBio(data.bio ?? '');
+      }
+    }
+
+    void fetchProfile();
   }, [open, user]);
 
   async function handleSave() {


### PR DESCRIPTION
- Add Stage/Driver/Status columns to all changelog tables
- Simplify status to planned | in-progress | complete
- Promote blueprint and tech-assessment to first-class Driver values
- Add F-001 sub-tasks (#53–56), update changelog and front matter
- Clean up SPEC_GUIDE: merge duplicate stage tables, document Driver values
- Migrate all spec status values to new vocabulary