### PR TITLE
fix: use Vercel env vars in ignoreCommand to correctly diff merge com…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
-  "ignoreCommand": "git diff --name-only HEAD^ HEAD | grep -qvE '\\.(md)$|^(docs|specs)/'"
+  "ignoreCommand": "git diff --name-only $VERCEL_GIT_PREVIOUS_SHA $VERCEL_GIT_COMMIT_SHA | grep -qvE '\\.(md)$|^(docs/|specs/)'"
 }


### PR DESCRIPTION
…mits

HEAD^ HEAD doesn't work reliably on merge commits — the diff can appear empty, causing Vercel to cancel builds that should run. Use $VERCEL_GIT_PREVIOUS_SHA..$VERCEL_GIT_COMMIT_SHA instead, which Vercel populates with the actual before/after SHAs for the deployment.